### PR TITLE
Handle nil belongs_to relationships differently than has_many nil

### DIFF
--- a/lib/restful/jsonapi/restify_param.rb
+++ b/lib/restful/jsonapi/restify_param.rb
@@ -34,7 +34,7 @@ module Restful
         if data_is_present?(relationship_data[:data]) && relationship_data[:data].is_a?(Array)
           restify_has_many(relationship_name, relationship_data)
         end
-        if relationship_data[:data].is_a? Hash
+        if relationship_data[:data].is_a?(Hash)
           restify_belongs_to(relationship_name, relationship_data)
         end
       end

--- a/lib/restful/jsonapi/restify_param.rb
+++ b/lib/restful/jsonapi/restify_param.rb
@@ -31,10 +31,10 @@ module Restful
       end
 
       def restify_relationship(relationship_name, relationship_data)
-        if data_is_present?(relationship_data[:data]) && relationship_data[:data].is_a? Array
+        if data_is_present?(relationship_data[:data]) && relationship_data[:data].is_a?(Array)
           restify_has_many(relationship_name, relationship_data)
         end
-        unless relationship_data[:data].is_a? Array
+        if relationship_data[:data].is_a? Hash
           restify_belongs_to(relationship_name, relationship_data)
         end
       end

--- a/lib/restful/jsonapi/restify_param.rb
+++ b/lib/restful/jsonapi/restify_param.rb
@@ -31,12 +31,11 @@ module Restful
       end
 
       def restify_relationship(relationship_name, relationship_data)
-        if data_is_present?(relationship_data[:data])
-          if relationship_data[:data].is_a? Array
-            restify_has_many(relationship_name, relationship_data)
-          else
-            restify_belongs_to(relationship_name, relationship_data)
-          end
+        if data_is_present?(relationship_data[:data]) && relationship_data[:data].is_a? Array
+          restify_has_many(relationship_name, relationship_data)
+        end
+        unless relationship_data[:data].is_a? Array
+          restify_belongs_to(relationship_name, relationship_data)
         end
       end
 
@@ -45,7 +44,11 @@ module Restful
           relationship_key = relationship_name.to_s.underscore+"_attributes"
           {relationship_key => restify_data(relationship_name,relationship_data[:data])}
         else
-          {"#{relationship_name.underscore}_id" => relationship_data[:data][:id]}
+          if relationship_data[:data].nil?
+            {"#{relationship_name.underscore}_id" => nil}
+          else
+            {"#{relationship_name.underscore}_id" => relationship_data[:data][:id]}
+          end
         end
       end
 

--- a/lib/restful/jsonapi/version.rb
+++ b/lib/restful/jsonapi/version.rb
@@ -1,5 +1,5 @@
 module Restful
   module Jsonapi
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end


### PR DESCRIPTION
Data that is serialized as `nil` in a `belongs_to` relationship should reset the relationship's id.

Before this PR it was ignored.

CC: @nehakapo @offirgolan 