### PR TITLE
Handle missing payload instead of blowing up

### DIFF
--- a/lib/restful/jsonapi/restify_param.rb
+++ b/lib/restful/jsonapi/restify_param.rb
@@ -13,8 +13,9 @@ module Restful
         if value == params
           value = params.clone[:data] # leave params alone
         end
-        value.delete(:type)
         new_params = ActionController::Parameters.new
+        return new_params if value.nil?
+        value.delete(:type)
         # relationships
         if value.has_key? :relationships
           value.delete(:relationships).each do |relationship_name, relationship_data|


### PR DESCRIPTION
When an incorrect payload is provided (e.g. `data` field is missing), `params.clone` returns nil, which then results in a call to delete method on nil object. Check if value is nil and return an empty parameters list in that case.